### PR TITLE
 Channels 2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,13 @@ Beatserver, a periodic task scheduler for django channels | beta software
 ### Configurations:
 
     # beatconfig.py
+    import os
     from datetime import timedelta
-
+    from channels.layers import get_channel_layer
+    
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "alamo_projects.settings")
+    channel_layers = get_channel_layer()
+    
     BEAT_SCHEDULE = {
         'add-every-10-seconds': {
             'channel_name': 'testing',
@@ -24,4 +29,4 @@ Beatserver, a periodic task scheduler for django channels | beta software
 
 ### How to run:
 
-    beatserver django_project.asgi:channel_layer
+    beatserver django_project.beatconfig:application

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Beatserver, a periodic task scheduler for django channels | beta software
     from datetime import timedelta
     from channels.layers import get_channel_layer
     
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "alamo_projects.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "django_project.settings")
     channel_layers = get_channel_layer()
     
     BEAT_SCHEDULE = {

--- a/beatserver/parser.py
+++ b/beatserver/parser.py
@@ -1,10 +1,4 @@
 import importlib
-try:
-    from channels import channel_layers
-    CHANNELS_2 = False
-except:
-    CHANNELS_2 = True
-
 
 class Parser(object):
     """
@@ -16,22 +10,16 @@ class Parser(object):
         self.module_path = module_path
 
     def check_in_memory(self):
-        if CHANNELS_2:
-            backend = type(self.get_channel_layer()).__name__
-            if backend == "InMemoryChannelLayer":
-                raise Exception(
-                    " beatserver will not support inmemory Channel layer")
-        else:
-            backend = channel_layers.configs['default']['BACKEND']
-            if backend == "asgiref.inmemory.ChannelLayer":
-                raise Exception(
-                    " beatserver will not support inmemory Channel layer")
+        backend = type(self.get_channel_layer()).__name__
+        if backend == "InMemoryChannelLayer":
+            raise Exception(
+                " beatserver will not support inmemory Channel layer")
 
     def get_module(self):
         return importlib.import_module(self.module_path)
 
     def get_channel_layer(self):
-        return self.get_module().channel_layers if CHANNELS_2 else self.get_module()
+        return self.get_module().channel_layers
 
     def get_beat_config(self):
         return self.get_module().BEAT_SCHEDULE

--- a/beatserver/parser.py
+++ b/beatserver/parser.py
@@ -1,5 +1,9 @@
 import importlib
-from channels import channel_layers
+try:
+    from channels import channel_layers
+    CHANNELS_2 = False
+except:
+    CHANNELS_2 = True
 
 
 class Parser(object):
@@ -12,16 +16,22 @@ class Parser(object):
         self.module_path = module_path
 
     def check_in_memory(self):
-        backend = channel_layers.configs['default']['BACKEND']
-        if backend == "asgiref.inmemory.ChannelLayer":
-            raise Exception(
-                " beatserver will not support inmemory Channel layer")
+        if CHANNELS_2:
+            backend = type(self.get_channel_layer()).__name__
+            if backend == "InMemoryChannelLayer":
+                raise Exception(
+                    " beatserver will not support inmemory Channel layer")
+        else:
+            backend = channel_layers.configs['default']['BACKEND']
+            if backend == "asgiref.inmemory.ChannelLayer":
+                raise Exception(
+                    " beatserver will not support inmemory Channel layer")
 
     def get_module(self):
         return importlib.import_module(self.module_path)
 
     def get_channel_layer(self):
-        return self.get_module()
+        return self.get_module().channel_layers if CHANNELS_2 else self.get_module()
 
     def get_beat_config(self):
         return self.get_module().BEAT_SCHEDULE

--- a/beatserver/server.py
+++ b/beatserver/server.py
@@ -1,10 +1,5 @@
 import logging
-try:
-    from channels import Channel
-    CHANNELS_2 = False
-except:
-    from asgiref.sync import async_to_sync
-    CHANNELS_2 = True
+from asgiref.sync import async_to_sync
 from twisted.internet import reactor, task
 
 logger = logging.getLogger(__name__)
@@ -21,10 +16,7 @@ class Server(object):
         self.beat_config = beat_config
 
     def run_task(self, channel_name, message):
-        if CHANNELS_2:
-            async_to_sync(self.channel_layer.send)(channel_name, message)
-        else:
-            Channel(channel_name).send(message)
+        async_to_sync(self.channel_layer.send)(channel_name, message)
         logger.info("Channel name {} with {} message delivered".format(
             channel_name, message))
 


### PR DESCRIPTION
These changes give beatserver Channels 2 support without dropping Channels 1 support. Admittedly the modifications are a bit hacky due to my inexperience and the difference between Channels 1 and Channels 2 APIs, so maybe it would make more sense to fork the project into a Channels-1 version and a Channels-2 version to keep the code clean...

In addition to the changes in these files, the beatserver.py file requires additional lines to work correctly in Channels 2 (no changes needed if the user wants to keep working with Channels 1) which should be documented in the README file. This is an example beatserver.py file that works with Channels 2:

import os
from datetime import timedelta
from channels.layers import get_channel_layer

os.environ.setdefault("DJANGO_SETTINGS_MODULE", "PROJECT_NAME.settings")

BEAT_SCHEDULE = {
    'send-every-5-seconds': {
        'channel_name': 'CHANNEL_NAME',
        'schedule': timedelta(seconds=5),
        'message': {'type': 'type_of_message', 'message': 'message_text'}
    },
}

channel_layers = get_channel_layer()

and the server needs to be initialized with the following command:

beatserver PROJECT_NAME.beatconfig:application

Putting all this information in the beatconfig.py file is necessary to get the channel_layer. This is due to the fact that in Channels 2 if you try to import the PROJECT_NAME.asgi file as was done for Channels 1 you get a conflict between a the reactor imported in Server.py and an asyncioreactor used by Daphne. Daphne notices the conflict and proceeds to uninstall automatically the synchronous beatserver reactor which breaks beatserver, so I had to move the necessary information to get the channel_layers to the beatconfig.py file.... I know that this quite inelegant and you'll probably want to find a better solution before merging my changes, but I thought you'd prefer to at least have some "first working solution" you can improve upon :-).