### PR TITLE
Added cron syntax (absolute scheduling) and multi-beat per channel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,22 @@ Beatserver, a periodic task scheduler for django channels | beta software
     from datetime import timedelta
 
     BEAT_SCHEDULE = {
-        'testing-print': {
-            'type': 'test.print',
-            'message': {'foo': 'bar'},
-            'schedule': timedelta(seconds=5)
-        },
+        'testing-print': [
+            {
+                'type': 'test.print',
+                'message': {'testing': 'one'},
+                'schedule': timedelta(seconds=5)  # Every 5 seconds
+            },
+            {
+                'type': 'test.print',
+                'message': {'testing': 'two'},
+                'schedule': '0 3 * * 1'  # Precisely at 3AM on Monday
+            },
+        ]
     }
+
+    Schedules can be specified as timedeltas for running tasks on specified intervals,
+    or as cron-syntax strings for running tasks on exact schedules.
 
 ### How to run:
 

--- a/beatserver/server.py
+++ b/beatserver/server.py
@@ -44,7 +44,7 @@ class BeatServer(StatelessServer):
         while True:
             schedule = value['schedule']
             if isinstance(schedule, timedelta):
-                sleep_seconds = value['schedule'].total_seconds()
+                sleep_seconds = schedule.total_seconds()
             else:
                 sleep_seconds = croniter(schedule).next() - time.time()
             await asyncio.sleep(sleep_seconds)

--- a/beatserver/server.py
+++ b/beatserver/server.py
@@ -30,9 +30,10 @@ class BeatServer(StatelessServer):
         emitters = []
         for key, value in self.beat_config.items():
             if isinstance(value, (list, tuple)):
-                emitters.extend(asyncio.ensure_future(
-                    self.emitters(key, v) for v in value
-                ))
+                for v in value:
+                    emitters.append(asyncio.ensure_future(
+                        self.emitters(key, v)
+                    ))
             else:
                 emitters.append(asyncio.ensure_future(
                     self.emitters(key, value)

--- a/beatserver/server.py
+++ b/beatserver/server.py
@@ -21,7 +21,7 @@ class BeatServer(StatelessServer):
         """
         # For each channel, launch its own listening coroutine
         listeners = []
-        for key, value in self.beat_config.items():
+        for key in self.beat_config.keys():
             listeners.append(asyncio.ensure_future(
                 self.listener(key)
             ))
@@ -29,9 +29,14 @@ class BeatServer(StatelessServer):
         # For each beat configuration, launch it's own sending pattern
         emitters = []
         for key, value in self.beat_config.items():
-            emitters.append(asyncio.ensure_future(
-                self.emitters(key, value)
-            ))
+            if isinstance(value, (list, tuple)):
+                emitters.extend(asyncio.ensure_future(
+                    self.emitters(key, v) for v in value
+                ))
+            else:
+                emitters.append(asyncio.ensure_future(
+                    self.emitters(key, value)
+                ))
 
         # Wait for them all to exit
         await asyncio.wait(emitters)

--- a/examples/examples/beatconfig.py
+++ b/examples/examples/beatconfig.py
@@ -2,9 +2,16 @@
 from datetime import timedelta
 
 BEAT_SCHEDULE = {
-    'testing-print': {
-        'type': 'test.print',
-        'message': {'testing': 'one'},
-        'schedule': timedelta(seconds=5)
-    },
+    'testing-print': [
+        {
+            'type': 'test.print',
+            'message': {'testing': 'one'},
+            'schedule': timedelta(seconds=5)  # Every 5 seconds
+        },
+        {
+            'type': 'test.print',
+            'message': {'testing': 'two'},
+            'schedule': '0 3 * * 1'  # Precisely at 3AM on Monday
+        },
+    ]
 }

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     description="Beat Server is is a scheduler",
     license='MIT',
     packages=find_packages(),
-    install_requires=['channels>=1.1.8.1'],
+    install_requires=['channels>=1.1.8.1', 'croniter>=0.3.30'],
     include_package_data=True
 
 )


### PR DESCRIPTION
I'm still testing this out locally but I figured I'd go ahead and throw up a PR.

This would add support for cron syntax for scheduling tasks at certain times versus just on certain intervals.

For example, I might want something to run specifically "at 3AM" versus "every 24 hours". This preserves the default intervals for timedelta objects in config.